### PR TITLE
implement Reset() for the stream

### DIFF
--- a/spdystream.go
+++ b/spdystream.go
@@ -27,13 +27,16 @@ func (s *stream) Write(buf []byte) (int, error) {
 	return s.spdyStream().Write(buf)
 }
 
+// TODO: make sure this is correct
+// there seem to be more problems in the SPDY library (see https://github.com/whyrusleeping/go-smux-spdystream/pull/5)
 func (s *stream) Close() error {
-	// Reset is spdystream's full bidirectional close.
-	// We expose bidirectional close as our `Close`.
-	// To close only half of the connection, and use other
-	// spdystream options, just get the stream with:
-	//  ssStream := (*ss.Stream)(stream)
-	return s.spdyStream().Reset()
+	return s.spdyStream().Close()
+}
+
+// TODO: make sure this is correct
+// there seem to be more problems in the SPDY library (see https://github.com/whyrusleeping/go-smux-spdystream/pull/5)
+func (s *stream) Reset() error {
+	return s.spdyStream().Close()
 }
 
 func (s *stream) SetDeadline(t time.Time) error {

--- a/spdystream.go
+++ b/spdystream.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	ss "github.com/docker/spdystream"
-	smux "github.com/jbenet/go-stream-muxer"
+	smux "github.com/libp2p/go-stream-muxer"
 )
 
 var ErrUseServe = errors.New("not implemented, use Serve")

--- a/spdystream_test.go
+++ b/spdystream_test.go
@@ -3,7 +3,7 @@ package peerstream_spdystream
 import (
 	"testing"
 
-	test "github.com/jbenet/go-stream-muxer/test"
+	test "github.com/libp2p/go-stream-muxer/test"
 )
 
 func TestSpdyStreamTransport(t *testing.T) {


### PR DESCRIPTION
I'm not entirely sure if `Cancel()` is the correct mapping for `Reset()`, but from the the SPDY docs this seems to be the closest match.