### PR TITLE
Fix build break

### DIFF
--- a/spdystream.go
+++ b/spdystream.go
@@ -91,7 +91,7 @@ func (c *conn) OpenStream() (smux.Stream, error) {
 	// wait for a response before writing. for some reason
 	// spdystream does not make forward progress unless you do this.
 	s.Wait()
-	return (*stream)(s), nil
+	return (*ss.Stream)(s), nil
 }
 
 // AcceptStream accepts a stream opened by the other side.
@@ -123,7 +123,7 @@ func (c *conn) Serve(handler smux.StreamHandler) {
 			// return
 		}
 
-		go handler((*stream)(s))
+		go handler((*ss.Stream)(s))
 	})
 }
 


### PR DESCRIPTION
`$ go get -u ./...`
`# github.com/whyrusleeping/go-smux-spdystream`
`../../../whyrusleeping/go-smux-spdystream/spdystream.go:94: cannot use (*stream)(s) (type *stream) as type streammux.Stream in return argument:`
`    *stream does not implement streammux.Stream (missing Reset method)`
`../../../whyrusleeping/go-smux-spdystream/spdystream.go:126: cannot use (*stream)(s) (type *stream) as type streammux.Stream in argument to handler:`
`    *stream does not implement streammux.Stream (missing Reset method)`
