### PR TITLE
remove conn.Serve, use conn.AcceptStream instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYsbrKfXboT5A5Zvh9YW7oPMpV4kNKFkx9bmanZRKj19y",
+      "hash": "QmY9JXR3FupnYAYJWK9aMr9bCpqWKcToQ1tz8DVGTrHpHw",
       "name": "go-stream-muxer",
-      "version": "2.0.0"
+      "version": "3.0.0"
     }
   ],
   "gxVersion": "0.7.0",

--- a/smux_test.go
+++ b/smux_test.go
@@ -1,0 +1,34 @@
+package peerstream_spdystream
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	test "github.com/libp2p/go-stream-muxer/test"
+)
+
+func TestSpdyStreamTransport(t *testing.T) {
+	// test.SubtestAll(t, Transport)
+
+	tests := []test.TransportTest{
+		test.SubtestSimpleWrite,
+		test.SubtestStress1Conn1Stream1Msg,
+		test.SubtestStress1Conn1Stream100Msg,
+		test.SubtestStress1Conn100Stream100Msg,
+		test.SubtestStress50Conn10Stream50Msg,
+		test.SubtestStress1Conn1000Stream10Msg,
+		test.SubtestStress1Conn100Stream100Msg10MB,
+		// broken:
+		// test.SubtestStreamOpenStress,
+		// broken:
+		// test.SubtestStreamReset,
+	}
+
+	for _, f := range tests {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "==== RUN %s\n", test.GetFunctionName(f))
+		}
+		f(t, Transport)
+	}
+}

--- a/spdystream_suite_test.go
+++ b/spdystream_suite_test.go
@@ -1,0 +1,13 @@
+package peerstream_spdystream
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestGoSmuxSpdystream(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GoSmuxSpdystream Suite")
+}

--- a/spdystream_test.go
+++ b/spdystream_test.go
@@ -1,34 +1,115 @@
 package peerstream_spdystream
 
 import (
-	"fmt"
-	"os"
-	"testing"
+	"io"
+	"net"
+	"time"
 
-	test "github.com/libp2p/go-stream-muxer/test"
+	smux "github.com/libp2p/go-stream-muxer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-func TestSpdyStreamTransport(t *testing.T) {
-	// test.SubtestAll(t, Transport)
+var _ = Describe("SPDY", func() {
+	var server, client smux.Conn
 
-	tests := []test.TransportTest{
-		test.SubtestSimpleWrite,
-		test.SubtestStress1Conn1Stream1Msg,
-		test.SubtestStress1Conn1Stream100Msg,
-		test.SubtestStress1Conn100Stream100Msg,
-		test.SubtestStress50Conn10Stream50Msg,
-		test.SubtestStress1Conn1000Stream10Msg,
-		test.SubtestStress1Conn100Stream100Msg10MB,
-		// broken:
-		// test.SubtestStreamOpenStress,
-		// broken:
-		// test.SubtestStreamReset,
-	}
+	Context("accepting streams", func() {
+		BeforeEach(func() {
+			// start the server
+			serverReady := make(chan struct{})
+			serverAddr := make(chan net.Addr)
+			go func() {
+				defer GinkgoRecover()
+				l, err := net.Listen("tcp", "localhost:0")
+				Expect(err).ToNot(HaveOccurred())
+				serverAddr <- l.Addr()
+				c, err := l.Accept()
+				Expect(err).ToNot(HaveOccurred())
+				server, err = Transport.NewConn(c, true)
+				Expect(err).ToNot(HaveOccurred())
+				close(serverReady)
+			}()
 
-	for _, f := range tests {
-		if testing.Verbose() {
-			fmt.Fprintf(os.Stderr, "==== RUN %s\n", test.GetFunctionName(f))
-		}
-		f(t, Transport)
-	}
-}
+			// start the client
+			addr := <-serverAddr
+			nconn, err := net.Dial("tcp", addr.String())
+			Expect(err).ToNot(HaveOccurred())
+			client, err = Transport.NewConn(nconn, false)
+			Expect(err).ToNot(HaveOccurred())
+			<-serverReady
+		})
+
+		AfterEach(func() {
+			server.Close()
+			client.Close()
+		})
+
+		It("returns an error when the connection is closed", func() {
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				_, err := server.AcceptStream()
+				Expect(err).To(MatchError(errClosed))
+				close(done)
+			}()
+			server.Close()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("returns an error when the connection is closed, even if there are streams in the queue", func() {
+			_, err := client.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			server.Close()
+			_, err = server.AcceptStream()
+			Expect(err).To(MatchError(errClosed))
+		})
+
+		It("waits for new streams", func() {
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				server.AcceptStream()
+				close(done)
+			}()
+			Consistently(done).ShouldNot(BeClosed())
+			// kill the goroutine, so that the race detector is happy
+			server.Close()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("accepts a new stream", func() {
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				str, err := server.AcceptStream()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = io.Copy(str, str)
+				Expect(err).ToNot(HaveOccurred())
+				close(done)
+			}()
+			str, err := client.OpenStream()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = str.Write([]byte("foobar"))
+			Expect(err).ToNot(HaveOccurred())
+			b := make([]byte, 6)
+			_, err = str.Read(b)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(b).To(Equal([]byte("foobar")))
+			str.Close()
+			Eventually(done).Should(BeClosed())
+		})
+
+		It("accepts multiple streams, that were opened before AcceptStream was called", func() {
+			n := 5
+			for i := 0; i < n; i++ {
+				_, err := client.OpenStream()
+				Expect(err).ToNot(HaveOccurred())
+			}
+			time.Sleep(50 * time.Millisecond)
+			for i := 0; i < n; i++ {
+				_, err := server.AcceptStream()
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	})
+})


### PR DESCRIPTION
`Serve` will be removed from the smux.Conn interface in libp2p/go-stream-muxer#16.